### PR TITLE
feat(mypage): mypage画面のレイアウト追加

### DIFF
--- a/src/app/mypage/latest-post/latest-post.component.html
+++ b/src/app/mypage/latest-post/latest-post.component.html
@@ -1,0 +1,12 @@
+<mat-card class="post-card">
+  <mat-card-header>
+    <div mat-card-avatar class="post-card-image"></div>
+    <mat-card-title class="user-name">user name</mat-card-title>
+    <mat-card-subtitle class="post-date">post date</mat-card-subtitle>
+  </mat-card-header>
+  <mat-card-content>
+    <p>
+      今日やること 今日やったこと 聞くこと　感想
+    </p>
+  </mat-card-content>
+</mat-card>

--- a/src/app/mypage/latest-post/latest-post.component.scss
+++ b/src/app/mypage/latest-post/latest-post.component.scss
@@ -1,0 +1,15 @@
+.post-card {
+  background-color: rgb(245, 235, 226);
+}
+.post-card-image {
+  width: 30px;
+  height: 30px;
+  background: rgb(211, 220, 231) center/cover;
+  border-radius: 50%;
+}
+.user-name {
+  font-size: 16px;
+}
+.post-date {
+  font-size: 14px;
+}

--- a/src/app/mypage/latest-post/latest-post.component.spec.ts
+++ b/src/app/mypage/latest-post/latest-post.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LatestPostComponent } from './latest-post.component';
+
+describe('LatestPostComponent', () => {
+  let component: LatestPostComponent;
+  let fixture: ComponentFixture<LatestPostComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LatestPostComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LatestPostComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/mypage/latest-post/latest-post.component.ts
+++ b/src/app/mypage/latest-post/latest-post.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { Message } from 'src/app/interfaces/message';
+
+@Component({
+  selector: 'app-latest-post',
+  templateUrl: './latest-post.component.html',
+  styleUrls: ['./latest-post.component.scss'],
+})
+export class LatestPostComponent implements OnInit {
+  @Input() latestPost: Message;
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/mypage/mypage.module.ts
+++ b/src/app/mypage/mypage.module.ts
@@ -4,12 +4,12 @@ import { CommonModule } from '@angular/common';
 import { MypageRoutingModule } from './mypage-routing.module';
 import { MypageComponent } from './mypage/mypage.component';
 
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatCardModule } from '@angular/material/card';
+import { LatestPostComponent } from './latest-post/latest-post.component';
 
 @NgModule({
-  declarations: [MypageComponent],
-  imports: [
-    CommonModule,
-    MypageRoutingModule
-  ]
+  declarations: [MypageComponent, LatestPostComponent],
+  imports: [CommonModule, MypageRoutingModule, MatTabsModule, MatCardModule],
 })
-export class MypageModule { }
+export class MypageModule {}

--- a/src/app/mypage/mypage/mypage.component.html
+++ b/src/app/mypage/mypage/mypage.component.html
@@ -1,1 +1,18 @@
-<p>mypage works!</p>
+<mat-card class="mypage-card">
+  <mat-card-header>
+    <div mat-card-avatar class="profile-image"></div>
+    <mat-card-title>user name</mat-card-title>
+    <mat-card-subtitle>エンジニア</mat-card-subtitle>
+  </mat-card-header>
+  <mat-card-content>
+    <p>
+      Angular ✖️ Firebaseの学習をつみあげます！
+    </p>
+  </mat-card-content>
+</mat-card>
+<mat-tab-group class="tab-group">
+  <mat-tab label="最近の投稿">
+    <app-latest-post></app-latest-post>
+  </mat-tab>
+  <mat-tab label="月別"></mat-tab>
+</mat-tab-group>

--- a/src/app/mypage/mypage/mypage.component.scss
+++ b/src/app/mypage/mypage/mypage.component.scss
@@ -1,0 +1,6 @@
+.profile-image {
+  width: 40px;
+  height: 40px;
+  background: rgb(218, 238, 224) center/cover;
+  border-radius: 50%;
+}


### PR DESCRIPTION
fix #60 

以下の実装をしましたので、レビューをお願いします。

### 実装内容
- mypage画面のレイアウト追加
- latestPostComponentを作成
- 最新の投稿にlatestPostComponentを表示

### イメージ
![image](https://user-images.githubusercontent.com/55618591/81641076-201e1a80-945b-11ea-98ad-69b05ba9538c.png)
