### PR TITLE
feat(welcome): welcome画面のレイアウト調整

### DIFF
--- a/src/app/welcome/button/button.component.html
+++ b/src/app/welcome/button/button.component.html
@@ -1,0 +1,12 @@
+<div class="button">
+  <div class="button__start">
+    <button mat-flat-button routerlink="/login" routerLinkActive="activate">
+      始める
+    </button>
+  </div>
+  <div class="button__login">
+    <button mat-flat-button routerlink="/login" routerLinkActive="activate">
+      ログイン
+    </button>
+  </div>
+</div>

--- a/src/app/welcome/button/button.component.html
+++ b/src/app/welcome/button/button.component.html
@@ -1,12 +1,10 @@
 <div class="button">
-  <div class="button__start">
-    <button mat-flat-button routerlink="/login" routerLinkActive="activate">
-      始める
-    </button>
-  </div>
-  <div class="button__login">
-    <button mat-flat-button routerlink="/login" routerLinkActive="activate">
-      ログイン
-    </button>
-  </div>
+  <button mat-flat-button routerlink="/login" routerLinkActive="activate">
+    始める
+  </button>
+</div>
+<div class="button">
+  <button mat-flat-button routerlink="/login" routerLinkActive="activate">
+    ログイン
+  </button>
 </div>

--- a/src/app/welcome/button/button.component.scss
+++ b/src/app/welcome/button/button.component.scss
@@ -1,6 +1,6 @@
 .button {
   text-align: center;
 }
-.button__start + .button__login {
+.button + .button {
   margin: 16px;
 }

--- a/src/app/welcome/button/button.component.scss
+++ b/src/app/welcome/button/button.component.scss
@@ -1,0 +1,10 @@
+.button {
+  &__start {
+    text-align: center;
+    padding: 12px;
+  }
+  &__login {
+    text-align: center;
+    padding: 12px;
+  }
+}

--- a/src/app/welcome/button/button.component.scss
+++ b/src/app/welcome/button/button.component.scss
@@ -1,7 +1,6 @@
 .button {
-  &__start,
-  &__login {
-    text-align: center;
-    padding: 12px;
-  }
+  text-align: center;
+}
+.button__start + .button__login {
+  margin: 16px;
 }

--- a/src/app/welcome/button/button.component.scss
+++ b/src/app/welcome/button/button.component.scss
@@ -1,8 +1,5 @@
 .button {
-  &__start {
-    text-align: center;
-    padding: 12px;
-  }
+  &__start,
   &__login {
     text-align: center;
     padding: 12px;

--- a/src/app/welcome/button/button.component.spec.ts
+++ b/src/app/welcome/button/button.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ButtonComponent } from './button.component';
+
+describe('ButtonComponent', () => {
+  let component: ButtonComponent;
+  let fixture: ComponentFixture<ButtonComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ButtonComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/welcome/button/button.component.ts
+++ b/src/app/welcome/button/button.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-button',
+  templateUrl: './button.component.html',
+  styleUrls: ['./button.component.scss']
+})
+export class ButtonComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/welcome/top-content/top-content.component.html
+++ b/src/app/welcome/top-content/top-content.component.html
@@ -1,0 +1,11 @@
+<div class="top-content">
+  <div class="top-content__catchphrase">
+    あなたの学びを
+    <br />
+    つみあげる
+  </div>
+  <div class="top-content__description">
+    <p>今日の目標やできたこと、今日の気づき</p>
+    <p>学びの記録をチャット感覚で。</p>
+  </div>
+</div>

--- a/src/app/welcome/top-content/top-content.component.scss
+++ b/src/app/welcome/top-content/top-content.component.scss
@@ -1,0 +1,16 @@
+.top-content {
+  padding: 12px;
+  margin-bottom: 24px;
+  &__catchphrase {
+    text-align: center;
+    margin: 24px 0;
+    font-size: 24px;
+    font-family: "Hiragino Kaku Gothic Pro", "ヒラギノ角ゴ Pro W3", "メイリオ",
+      Meiryo, "ＭＳ Ｐゴシック", sans-serif;
+  }
+  &__description {
+    text-align: center;
+    font-size: 12px;
+    color: rgba(black, 0.5);
+  }
+}

--- a/src/app/welcome/top-content/top-content.component.spec.ts
+++ b/src/app/welcome/top-content/top-content.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TopContentComponent } from './top-content.component';
+
+describe('TopContentComponent', () => {
+  let component: TopContentComponent;
+  let fixture: ComponentFixture<TopContentComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TopContentComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TopContentComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/welcome/top-content/top-content.component.ts
+++ b/src/app/welcome/top-content/top-content.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-top-content',
+  templateUrl: './top-content.component.html',
+  styleUrls: ['./top-content.component.scss']
+})
+export class TopContentComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/welcome/welcome.module.ts
+++ b/src/app/welcome/welcome.module.ts
@@ -5,9 +5,11 @@ import { WelcomeRoutingModule } from './welcome-routing.module';
 import { WelcomeComponent } from './welcome/welcome.component';
 
 import { MatButtonModule } from '@angular/material/button';
+import { TopContentComponent } from './top-content/top-content.component';
+import { ButtonComponent } from './button/button.component';
 
 @NgModule({
-  declarations: [WelcomeComponent],
+  declarations: [WelcomeComponent, TopContentComponent, ButtonComponent],
   imports: [CommonModule, WelcomeRoutingModule, MatButtonModule],
 })
 export class WelcomeModule {}

--- a/src/app/welcome/welcome/welcome.component.html
+++ b/src/app/welcome/welcome/welcome.component.html
@@ -1,10 +1,5 @@
-<p>サービス説明</p>
-
-<a
-  mat-raised-button
-  color="primary"
-  routerLink="/login"
-  routerLinkActive="activate"
->
-  開始する
-</a>
+<div class="welcome">
+  <div class="container">
+    <app-top-content></app-top-content> <app-button></app-button>
+  </div>
+</div>

--- a/src/app/welcome/welcome/welcome.component.scss
+++ b/src/app/welcome/welcome/welcome.component.scss
@@ -1,0 +1,6 @@
+.welcome {
+  background-color: rgb(236, 217, 217);
+}
+.container {
+  margin: 0 24px;
+}


### PR DESCRIPTION
fix #13 

また後日変更しますが、一旦ここまでの実装のレビューをお願いします。

 ### 実装内容
- welcome画面のレイアウト調整
- top-contentとbuttonのコンポーネント作成

 ### イメージ
![image](https://user-images.githubusercontent.com/55618591/81881464-31863480-95cb-11ea-979f-6ce5e780d9cc.png)
